### PR TITLE
scrapy is not required

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Make sure Scrapy and the ScrapeOps Monitor is installed:
 
 ```
 
-pip install scrapy scrapeops-scrapy
+pip install scrapeops-scrapy
 
 ```
 


### PR DESCRIPTION
had a run of this indeed_ jobs spider this morning. 
not able to install  "pip install **scrapy** scrapeops-scrapy" 
until I saw this https://pypi.org/project/scrapeops-scrapy/